### PR TITLE
test: enabled to check response body with root/health endpoint.

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -18,21 +18,26 @@ func TestDefaultRouteCode(t *testing.T) {
 }
 
 func TestDefaultRouteBody(t *testing.T) {
-	req, _ := http.NewRequest(http.MethodGet, "/", nil)
-	resp := httptest.NewRecorder()
+	// If we have both positive/negative case for each API endpoint,
+	// we can use SubTesting with t.Run()
+	t.Run("Positive Case", func(t *testing.T) {
+		expected := "{\"content\":\"hello, developers\"}\n"
+		req, _ := http.NewRequest(http.MethodGet, "/", nil)
+		resp := httptest.NewRecorder()
 
-	// Call imported & targeted function
-	DefaultRoute(resp, req)
+		// Call imported & targeted function
+		DefaultRoute(resp, req)
 
-	got := resp.Body.String()
-	// fmt.Printf("type of got: %T \n", got)
-	expected := "{\"content\":\"hello, developers\"}\n"
+		got := resp.Body.String()
+		// fmt.Printf("type of got: %T \n", got)
 
-	if got != expected {
-		t.Errorf("got: [ %q ], expected: [ %q ] \n", got, expected)
-		t.Errorf("Called endpoint: %s \n", req.URL)
-		t.Errorf("Got Status code: %d \n", resp.Code)
-	}
+		if got != expected {
+			t.Errorf("got: [ %q ], expected: [ %q ] \n", got, expected)
+			t.Errorf("Called endpoint: %s \n", req.URL)
+			t.Errorf("Got Status code: %d \n", resp.Code)
+		}
+	})
+
 }
 
 func TestHealthCheckRouteCode(t *testing.T) {


### PR DESCRIPTION
## Issue/PR link
closes: #5 

## What does this PR do?
Describe what changes you make in your branch:
- enabled to check response body as string type, within `go test`.
- added subtest to one of the test case for future maintenance

## (Optional) Additional Contexts
Describe additional information for reviewers (i.e. What does not included)
- As we need to use `net/http` for target API endpoints, we can use `httptest.NewRecorder()` for creating mocks from`net/http/httptest` and `http.NewRequest()` for defining client behaviors ([ref](https://developersblog.dmm.com/entry/2024/12/09/110000))
- With this methods, we can use `resp.Body.String()` to obtain string values of response body, so we can assert this with expected response body.